### PR TITLE
refactor(postgres): change Cmd to Entrypoint for spiffe-helper

### DIFF
--- a/image/postgres.nix
+++ b/image/postgres.nix
@@ -10,7 +10,7 @@ pkgs.dockerTools.buildLayeredImage {
   ];
 
   config = {
-    Cmd = [ "${pkgs.spiffe-helper}/bin/spiffe-helper" ];
+    Entrypoint = [ "${pkgs.spiffe-helper}/bin/spiffe-helper" ];
     Env = [
       "PATH=/bin"
     ];


### PR DESCRIPTION
Replace Cmd with Entrypoint in Docker image configuration to properly set the container entrypoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)